### PR TITLE
Intergate translation service 

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ Supported features:
 
 > Ruslin is a reproducible build of app, you don't need to worry about F-Droid and other store signature issues, see: [Towards a reproducible F-Droid](https://f-droid.org/en/2023/01/15/towards-a-reproducible-fdroid.html).
 
+
+## Translation
+
+Please help to translate with the [Weblate](https://toolate.othing.xyz/projects/ruslin-android/) 
+
+<a href="https://toolate.othing.xyz/projects/ruslin-android/">
+<img src="https://toolate.othing.xyz/widget/ruslin-android/app/multi-auto.svg" alt="Translation status" />
+</a>
+
+
 ## Build
 
 The following instructions are based on a Linux development environment and an arm64 physical device for debugging.


### PR DESCRIPTION
To make it easier to translate there exists a few translation services:

* https://hosted.weblate.org/ from creator of the Weblate online platform that itself is FOSS. It has pre-moderation for FOSS projects. It doesn't offer free automatic translations, only the LibreTranslate that almost not working. But you can buy and integrate own API key to Google Translate, Yandex, DeepL, Baidu, etc. It will periodically send translations as a PR on the GitHub.
* https://translate.codeberg.org/ also based on Weblate, doesn't have a pre-moderation which is a plus. It can't send a PR on GitHub because they are competitors.
* https://toolate.othing.xyz/ based on Weblate, no pre-moderation, can send a PR, has automatic translations from Baidu that gives good results. It's supported by F-Droid translators and hosted in Singapore.
* Crowdin.com has pre-moderation for FOSS, has a better UI.
* Transifex, Lokalize.com, PoEditor.com maybe some other may be also good but less often used.


### Suggested solution

I created a translation project for you on the Toolate https://toolate.othing.xyz/projects/ruslin-android/.
You can translate the Android app strings and the app's description in F-Droid and PlayStore.
Once a day it will collect all translations into one commit and send in a PR. You may merge the PR once before a release, or even pull the changes manually from the git.

If you are ok with the solution then merge the PR with a link to the Toolate in the README to help users to find it. Also if you are interested I can send you an invitation to become an admin of the translation project (needed sometimes to resolve merge conflicts).
